### PR TITLE
Dodanie gitignore i zastąpienie deprcated np.float – float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+.pve/
+.pve3/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt

--- a/Rozdzial_4/r4_04.py
+++ b/Rozdzial_4/r4_04.py
@@ -14,8 +14,8 @@ import numpy as np
 class CosmicObject:  # Definiujemy poszczególne obiekty kosmiczne (Słońce, Ziemia,...)
     def __init__(self, name, rad, color, r, v):
         self.name = name
-        self.r = np.array(r, dtype=np.float)  # Wektory promienia odległości od Słońca
-        self.v = np.array(v, dtype=np.float)  # Wektory prędkości względem Słońca
+        self.r = np.array(r, dtype=float)  # Wektory promienia odległości od Słońca
+        self.v = np.array(v, dtype=float)  # Wektory prędkości względem Słońca
         self.xs = []  # Kolejne pozycje X
         self.ys = []  # Kolejne pozycje Y
         # Właściwości odwołujące się do okna z animacją


### PR DESCRIPTION
Jak w temacie. Gitignore jest potrzebny, bo git niepotrzebnie  chce synchronizować np. __pycache__ itd. np.float to alias float i został odrzucony.