### PR TITLE
Uproszczenie kodu sprawdzającego poprawność importów.

### DIFF
--- a/Rozdzial_4/r4_01.py
+++ b/Rozdzial_4/r4_01.py
@@ -5,45 +5,15 @@
 from sys import exit
 from r4_functions import *
 
-load_module_ok = True
-
 try:
+    import matplotlib.pyplot as plt
+    import matplotlib.animation as animation
     import numpy as np
-
-    ok_module_info("numpy")
-except:
-    error_module_info("numpy")
-    load_module_ok = False
-
-try:
-    import matplotlib
-
-    ok_module_info("matplotlib")
-except:
-    err_module_info("matplotlib")
-    load_module_ok = False
-
-try:
     from astropy.time import Time
-
-    ok_module_info("astropy")
-except:
-    error_module_info("astropy")
-    load_module_ok = False
-
-
-try:
     from astroquery.jplhorizons import Horizons
-
-    ok_module_info("astroquery")
-except:
-    error_module_info("astroquery")
-    load_module_ok = False
-
-if not load_module_ok:
+    ok_module_info(["matplotlib", "astropy", "astroquery"])
+except ImportError as impErr:
+    load_module_ok = error_module_info(impErr.args[0])
     print("Niestety, wystąpiły błędy.")
     print("Nie mogę dalej działać.")
     exit(0)
-
-# Teraz mamy zainstalowane wszystkie moduły 
-print("Super! Możemy działać.")

--- a/Rozdzial_4/r4_02.py
+++ b/Rozdzial_4/r4_02.py
@@ -5,48 +5,18 @@
 from sys import exit
 from r4_functions import *
 
-load_module_ok = True
-
 try:
+    import matplotlib.pyplot as plt
+    import matplotlib.animation as animation
     import numpy as np
-
-    ok_module_info("numpy")
-except:
-    error_module_info("numpy")
-    load_module_ok = False
-
-try:
-    import matplotlib
-
-    ok_module_info("matplotlib")
-except:
-    err_module_info("matplotlib")
-    load_module_ok = False
-
-try:
     from astropy.time import Time
-
-    ok_module_info("astropy")
-except:
-    error_module_info("astropy")
-    load_module_ok = False
-
-
-try:
     from astroquery.jplhorizons import Horizons
-
-    ok_module_info("astroquery")
-except:
-    error_module_info("astroquery")
-    load_module_ok = False
-
-if not load_module_ok:
+    ok_module_info(["matplotlib", "astropy", "astroquery"])
+except ImportError as impErr:
+    load_module_ok = error_module_info(impErr.args[0])
     print("Niestety, wystąpiły błędy.")
     print("Nie mogę dalej działać.")
     exit(0)
-
-# Teraz mamy zainstalowane wszystkie moduły
-print("Super! Możemy działać.")
 
 nasaids = [1, 2, 3, 4]  # Numery ID w bazie NASA
 names = ["Merkury", "Wenus", "Ziemia", "Mars"]

--- a/Rozdzial_4/r4_03.py
+++ b/Rozdzial_4/r4_03.py
@@ -5,51 +5,19 @@
 
 from sys import exit
 from r4_functions import *
-import matplotlib.pyplot as plt
-
-
-load_module_ok = True
 
 try:
+    import matplotlib.pyplot as plt
+    import matplotlib.animation as animation
     import numpy as np
-
-    ok_module_info("numpy")
-except:
-    error_module_info("numpy")
-    load_module_ok = False
-
-try:
-    import matplotlib
-
-    ok_module_info("matplotlib")
-except:
-    err_module_info("matplotlib")
-    load_module_ok = False
-
-try:
     from astropy.time import Time
-
-    ok_module_info("astropy")
-except:
-    error_module_info("astropy")
-    load_module_ok = False
-
-
-try:
     from astroquery.jplhorizons import Horizons
-
-    ok_module_info("astroquery")
-except:
-    error_module_info("astroquery")
-    load_module_ok = False
-
-if not load_module_ok:
+    ok_module_info(["matplotlib", "astropy", "astroquery"])
+except ImportError as impErr:
+    load_module_ok = error_module_info(impErr.args[0])
     print("Niestety, wystąpiły błędy.")
     print("Nie mogę dalej działać.")
     exit(0)
-
-# Teraz mamy zainstalowane wszystkie moduły
-print("Super! Możemy działać.")
 
 nasaids = [1, 2, 3, 4]  # Numery ID w bazie NASA
 names = ["Merkury", "Wenus", "Ziemia", "Mars"]

--- a/Rozdzial_4/r4_04.py
+++ b/Rozdzial_4/r4_04.py
@@ -1,17 +1,27 @@
 # program r4_04.py
-# Sprawdzamy, czy mamy zainstalowane odpowiednie biblilteki zewnętrzne
-# Importujemy funkcje dodatkowe
 # Wprowadzamy kod z projektu https://github.com/chongchonghe/Python-solar-system
 
 from sys import exit
+from datetime import datetime, timedelta
 from r4_functions import *
-import matplotlib.pyplot as plt
-import matplotlib.animation as animation
-from datetime import date, datetime, timedelta
-import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.animation as animation
+    import numpy as np
+    from astropy.time import Time
+    from astroquery.jplhorizons import Horizons
+    ok_module_info(["matplotlib", "astropy", "astroquery"])
+except ImportError as impErr:
+    load_module_ok = error_module_info(impErr.args[0])
+    print("Niestety, wystąpiły błędy.")
+    print("Nie mogę dalej działać.")
+    exit(0)
+
+# Definiujemy poszczególne obiekty kosmiczne (Słońce, Ziemia,...)
 
 
-class CosmicObject:  # Definiujemy poszczególne obiekty kosmiczne (Słońce, Ziemia,...)
+class CosmicObject:
     def __init__(self, name, rad, color, r, v):
         self.name = name
         self.r = np.array(r, dtype=float)  # Wektory promienia odległości od Słońca
@@ -77,49 +87,6 @@ class SolarSystem:
         # Zwracamy wartości niezbędne do wygenerowania animacji
         return plots + lines + [self.timestamp]
 
-
-load_module_ok = True
-
-try:
-    import numpy as np
-
-    ok_module_info("numpy")
-except:
-    error_module_info("numpy")
-    load_module_ok = False
-
-try:
-    import matplotlib
-
-    ok_module_info("matplotlib")
-except:
-    err_module_info("matplotlib")
-    load_module_ok = False
-
-try:
-    from astropy.time import Time
-
-    ok_module_info("astropy")
-except:
-    error_module_info("astropy")
-    load_module_ok = False
-
-
-try:
-    from astroquery.jplhorizons import Horizons
-
-    ok_module_info("astroquery")
-except:
-    error_module_info("astroquery")
-    load_module_ok = False
-
-if not load_module_ok:
-    print("Niestety, wystąpiły błędy.")
-    print("Nie mogę dalej działać.")
-    exit(0)
-
-# Teraz mamy wszystkie moduły zainstalowane
-print("Super! Możemy działać....")
 
 nasaids = [1, 2, 3, 4]  # numery ID w bazie NASA
 names = ["Merkury", "Wenus", "Ziemia", "Mars"]

--- a/Rozdzial_4/r4_functions.py
+++ b/Rozdzial_4/r4_functions.py
@@ -1,14 +1,15 @@
 # r4_functions.py - funkcje dodatkowe
 
-
-def ok_module_info(name):
-    print(f"Moduł: {name} - zainstalowany poprawnie")
+def ok_module_info(names):
+    print(f"Moduły: {', '.join(names)} – zainstalowano poprawnie!")
+    print("Super! Możemy działać....")
 
 
 def error_module_info(name):
-    print(f"Brak modułu: {name}")
-    print(f"Instalacja poleceniem: pip install {name}")
+    print(f"{name}")
+    print("Instalacja poleceniem: pip install", name[16:].replace("'", ""))
     print("-----------------------")
+    return False
 
 
 def get_horizon_data(nasaids, names, colors, sizes, start_date="2018-01-01"):

--- a/Rozdzial_5/r5_00.py
+++ b/Rozdzial_5/r5_00.py
@@ -1,15 +1,17 @@
 # program r5_00.py
 # pandas
 
-from sys import exit
+import sys
 
 try:
     import pandas as pd
-
     print("Moduł pandas wczytany.")
-except:
-    print("Zainstaluj: 'pip install pandas' ")
-    exit(0)
+    import matplotlib.pyplot as plt
+    print("Moduł matplotlib obecny.")
+except ImportError as impErr:
+    print("Brak modułu", impErr.args[0][16:].replace("'", ""))
+    print("Zainstaluj: pip install", impErr.args[0][16:].replace("'", ""))
+    sys.exit(0)
 
 # Jest ok, działamy dalej
 source_data = "http://otwartedane.gdynia.pl/portal/data/city/6/3/data.csv"

--- a/Rozdzial_5/r5_01_data_frame.py
+++ b/Rozdzial_5/r5_01_data_frame.py
@@ -1,15 +1,17 @@
 # program r5_01_data_frame.py
 # pandas
 
-from sys import exit
+import sys
 
 try:
     import pandas as pd
-
     print("Moduł pandas wczytany.")
-except:
-    print("Zainstaluj: 'pip install pandas' ")
-    exit(0)
+    import matplotlib.pyplot as plt
+    print("Moduł matplotlib obecny.")
+except ImportError as impErr:
+    print("Brak modułu", impErr.args[0][16:].replace("'", ""))
+    print("Zainstaluj: pip install", impErr.args[0][16:].replace("'", ""))
+    sys.exit(0)
 
 # Jest ok, działamy dalej
 source_data = "http://otwartedane.gdynia.pl/portal/data/city/6/3/data.csv"

--- a/Rozdzial_5/r5_02.py
+++ b/Rozdzial_5/r5_02.py
@@ -1,15 +1,17 @@
 # program r5_02.py
 # pandas
 
-from sys import exit
+import sys
 
 try:
     import pandas as pd
-
     print("Moduł pandas wczytany.")
-except:
-    print("Zainstaluj: 'pip install pandas' ")
-    exit(0)
+    import matplotlib.pyplot as plt
+    print("Moduł matplotlib obecny.")
+except ImportError as impErr:
+    print("Brak modułu", impErr.args[0][16:].replace("'", ""))
+    print("Zainstaluj: pip install", impErr.args[0][16:].replace("'", ""))
+    sys.exit(0)
 
 # Jest ok, działamy dalej
 source_data = "http://otwartedane.gdynia.pl/portal/data/city/6/3/data.csv"
@@ -23,7 +25,7 @@ try:
     df = pd.read_csv(source_data)
     print("Pobrano dane źródłowe.")
 except:
-    print("UWAGA! wystąpił błąd.")
+    print("UWAGA! Wystąpił błąd.")
     exit(0)
 
 # Wyświetlamy dane pobrane z sieci


### PR DESCRIPTION
Kod importujący moduły jest niepotrzebnie rozbudowany. Ponadto w klauzuli except nie ma wskazanego przechwytywanego wyjątku, a powinien. W plikach r4_03.py i r4_04.py, gdzie matplotlib importowany jest na samym początku interpreter i tak wyrzuca błąd. Proponuję kod uprościć.